### PR TITLE
Sleep 30s between batches in ingestor upload session

### DIFF
--- a/upload_files_from_remote.py
+++ b/upload_files_from_remote.py
@@ -74,6 +74,7 @@ import argparse
 import json
 import os
 import sys
+import time
 
 import requests
 
@@ -257,6 +258,9 @@ def create_ingestor_upload_session(
             timeout=60,
         )
         _raise_for_status(response, f"Create Ingestor Upload Session (batch {batch_num})")
+        # rate limit between batches; skip sleep after the final batch
+        if batch_start + MAX_URLS_PER_REQUEST < len(data_urls):
+            time.sleep(30)
 
         result = response.json()
         results.append(result)


### PR DESCRIPTION
## Summary
- Adds a 30-second sleep between batch requests in `create_ingestor_upload_session` to avoid rate-limiting
- Sleep is skipped after the final batch

## Test plan
- [ ] Run with a URL count exceeding 1000 and confirm 30s pause between batches